### PR TITLE
update default Hyperledger Fabric version in READMEmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repo is a snippet of the fabcar [fabric sample](https://github.com/hyperledger/fabric-samples) with the basic network. It also includes our [fabric-node-chaincode-utils](https://github.com/wearetheledger/fabric-node-chaincode-utils) to test and develop nodejs chaincode. It contains a fabric network with 1 peer and 1 CA.
 
 ## Starting 
-Before starting, you will need to pull all the images of Hyperledger fabric to your desktop and tag them as latest. We included a script to do this. By default it will try to pull in `1.2.0` but you can pull a custom version by adding the version as a parameter.
+Before starting, you will need to pull all the images of Hyperledger fabric to your desktop and tag them as latest. We included a script to do this. By default it will try to pull in `1.3.0` but you can pull a custom version by adding the version as a parameter.
 ```bash
 ./scripts/bootstrap.sh [optional_custom_version]
 ```


### PR DESCRIPTION
Signed-off-by: Charlie van Rantwijk <charlievanrantwijk@gmail.com>

By default the boilerplate pulls 1.3 now after pull request #13. This updates the readme to reflect the change.